### PR TITLE
Simulation_Time methods useful for multilayer

### DIFF
--- a/include/simulation_time/Simulation_Time.h
+++ b/include/simulation_time/Simulation_Time.h
@@ -92,6 +92,7 @@ class Simulation_Time
      */ 
     std::string get_timestamp(int current_output_time_index)
     {
+        // "get" method mutates state!
         current_date_time_epoch = start_date_time_epoch + current_output_time_index * output_interval_seconds;
             
         struct tm *temp_gmtime_struct;
@@ -108,6 +109,29 @@ class Simulation_Time
 
         return current_timestamp;
     }
+
+    inline int next_timestep_index(int epoch_time_seconds)
+    {
+        return int(epoch_time_seconds - start_date_time_epoch) / output_interval_seconds;
+    }
+
+    inline int next_timestep_index()
+    {
+        return next_timestep_index(current_date_time_epoch);
+    }
+
+    inline time_t next_timestep_epoch_time(int epoch_time_seconds){
+        return start_date_time_epoch + ( next_timestep_index(epoch_time_seconds) * output_interval_seconds );
+    }
+
+    inline time_t next_timestep_epoch_time(){
+        return next_timestep_epoch_time(current_date_time_epoch);
+    }
+
+    inline int diff(const Simulation_Time& other){
+        return start_date_time_epoch - other.start_date_time_epoch;
+    }
+
 
     private:
 

--- a/test/simulation_time/Simulation_Time_Test.cpp
+++ b/test/simulation_time/Simulation_Time_Test.cpp
@@ -70,4 +70,55 @@ TEST_F(SimulationTimeTest, TestSimulationTime)
 
 }
 
+TEST_F(SimulationTimeTest, TestSimTimeNextIndex)
+{
+    simulation_time_params other_stp("2015-12-14 21:00:00", "2015-12-30 23:00:00", 3600);
+
+    int next_index;
+
+    // for 2.5h in the future
+    next_index = Simulation_Time_Object1->next_timestep_index(other_stp.start_t + (3600 * 2.5));
+
+    EXPECT_EQ(2, next_index);
+
+    // for 2.0h in the future
+    next_index = Simulation_Time_Object1->next_timestep_index(other_stp.start_t + (3600 * 2.00));
+
+    EXPECT_EQ(2, next_index);
+
+}
+
+TEST_F(SimulationTimeTest, TestSimTimeNextEpochTime)
+{
+    simulation_time_params other_stp("2015-12-14 21:00:00", "2015-12-30 23:00:00", 3600);
+
+    int next_time;
+
+    // for 2.5h in the future
+    next_time = Simulation_Time_Object1->next_timestep_epoch_time(other_stp.start_t + (3600 * 2.5));
+
+    EXPECT_EQ(other_stp.start_t + (3600 * 2.0), next_time);
+
+    // for 2.0h in the future
+    next_time = Simulation_Time_Object1->next_timestep_epoch_time(other_stp.start_t + (3600 * 2.00));
+
+    EXPECT_EQ(other_stp.start_t + (3600 * 2.0), next_time);
+
+}
+
+TEST_F(SimulationTimeTest, TestSimTimeDiff)
+{
+    simulation_time_params other_stp("2015-12-14 23:00:00", "2015-12-30 23:00:00", 3600);
+    Simulation_Time other_st(other_stp);
+    int diff;
+
+    diff = other_st.diff(*Simulation_Time_Object1);
+
+    EXPECT_EQ(7200, diff);
+
+    diff = Simulation_Time_Object1->diff(other_st);
+
+    EXPECT_EQ(-7200, diff);
+
+}
 


### PR DESCRIPTION
Additions to `Simulation_Time` ... suggest using an instance per layer and this can encapsulate the integer division needed for non-uniform timesteps--and lays the groundwork for nonuniform simulation starts between layers.

## Additions

-

## Removals

-

## Changes

-

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist (automated report can be put here)

1.

### Target Environment support

- [ ] Linux
